### PR TITLE
Fix a typo

### DIFF
--- a/docs/04_Run_changes_in_App.md
+++ b/docs/04_Run_changes_in_App.md
@@ -2,7 +2,7 @@
 
 You should develop and test your changes with the JUnit environment that is
 provided by the NewPipe Extractor and IDEA. If you want to try it with
-the actual fronted, you need to follow these steps.
+the actual frontend, you need to follow these steps.
 
 ### Setup Android Studio
 


### PR DESCRIPTION
'fronted' -> 'frontend' in https://teamnewpipe.github.io/documentation/04_Run_changes_in_App/

Fixes #39