### PR TITLE
Some release instruction fixes

### DIFF
--- a/docs/07_release_instructions.md
+++ b/docs/07_release_instructions.md
@@ -112,7 +112,7 @@ Now there should be two new commits (the Weblate and changelog ones) on your loc
     - `git add app/build.gradle`
     - `git commit -m "Release vX.X.X (NEW_VERSION_CODE)"`
 - Push the newly created branch to the NewPipe repo
-    - `git push upstream release-X.X.X`
+    - `git push origin release-X.X.X`
 
 ## Creating the Pull Request
 
@@ -243,7 +243,7 @@ Currently @TheAssassin is the only holder of NewPipe's APK signing keys. Therefo
 - Go to the draft changelog [kept on GitHub](https://github.com/TeamNewPipe/NewPipe/releases)
 - Set `vX.X.X` as the tag name
 - Set `vX.X.X` as the release title
-- Set `dev` as the "Target:" branch
+- Set `master` as the "Target:" branch
 - Attach the signed APK @TheAssassin sent you
 - Publish the release
 - Profit :-D


### PR DESCRIPTION
I noticed these two issues in the release instructions when releasing v0.23.3.

The upstream->origin error is caused by me using `upstream` instead of `origin` as the NewPipe official repo remote name, and I forgot to replace it with `origin` in this case (all other times, I did).
The other change is about creating the release tag on the correct branch (`master` and not `dev`). When releasing v0.23.1 I did this wrong and accidentally targeted `dev`, resulting in commit [d81607c](https://github.com/TeamNewPipe/NewPipe/commit/d81607c9d58b3624dd239e729a34f6d3423fa561) being tagged. Fortunately it didn't make any difference because, even though that commit was on the `dev` branch, it was just one merge commit away from the `master` branch. But in other cases (such as hotfix v0.23.3) the correct target branch is obviosly `master`, otherwise F-Droid will build the code from `dev`!